### PR TITLE
Refine VASP tutorials & Utilities: INCAR consistency, HSE ALGO=All, tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,176 +1,29 @@
-https://jiayihua2001.github.io/Basic_training/
+# Basic Training — Noa Marom Research Group
 
-# just-the-docs-template
+Onboarding documentation for new group members. The content lives in `docs/`, is built with the [Just the Docs](https://just-the-docs.github.io/just-the-docs/) Jekyll theme, and is published to GitHub Pages:
 
-This is a *bare-minimum* template to create a [Jekyll] site that:
+**https://jiayihua2001.github.io/Basic_training/**
 
-- uses the [Just the Docs] theme;
-- can be built and published on [GitHub Pages];
-- can be built and previewed locally, and published on other platforms.
+## What's inside
 
-More specifically, the created site:
+- **HPC Onboard** — getting started on the group's clusters (Trace, Arjuna, NERSC Perlmutter) plus Linux, Slurm, and Python-environment basics.
+- **Tutorials**
+  - **FHI-aims** (organic / molecular materials) — H₂ → periodic solids → 2D & surfaces.
+  - **VASP** (inorganic / quantum materials, on Perlmutter) — bulk InAs at PBE → PBE+SOC → HSE06, with the SOC / HSE / DFT+U methodology and parallel-execution details.
+- **Utilities** — the tools and helper scripts the tutorials use: VASPKIT, vaspvis, OgreInterface, BayesianOpt4dftu, ASE / pymatgen, the `incar.py` / `kpoints.py` / `potcar.sh` helpers, and AI coding assistants.
 
-- uses a gem-based approach, i.e. uses a `Gemfile` and loads the `just-the-docs` gem;
-- uses the [GitHub Pages / Actions workflow] to build and publish the site on GitHub Pages.
+The aim is not a fixed recipe but the workflow, programming logic, and physics needed to do independent research.
 
-To get started with creating a site, simply:
+## Local preview
 
-1. click "[use this template]" to create a GitHub repository
-2. go to Settings > Pages > Build and deployment > Source, and select GitHub Actions
+```bash
+cd docs
+bundle install
+bundle exec jekyll serve     # serves http://localhost:4000/Basic_training/
+```
 
-If you want to maintain your docs in the `docs` directory of an existing project repo, see [Hosting your docs from an existing project repo](#hosting-your-docs-from-an-existing-project-repo).
+The site rebuilds and deploys automatically on every push to `main` via `.github/workflows/ci.yml`.
 
-After completing the creation of your new site on GitHub, update it as needed:
+## License
 
-## Replace the content of the template pages
-
-Update the following files to your own content:
-
-- `index.md` (your new home page)
-- `README.md` (information for those who access your site repo on GitHub)
-
-## Changing the version of the theme and/or Jekyll
-
-Simply edit the relevant line(s) in the `Gemfile`.
-
-## Adding a plugin
-
-The Just the Docs theme automatically includes the [`jekyll-seo-tag`] plugin.
-
-To add an extra plugin, you need to add it in the `Gemfile` *and* in `_config.yml`. For example, to add [`jekyll-default-layout`]:
-
-- Add the following to your site's `Gemfile`:
-
-  ```ruby
-  gem "jekyll-default-layout"
-  ```
-
-- And add the following to your site's `_config.yml`:
-
-  ```yaml
-  plugins:
-    - jekyll-default-layout
-  ```
-
-Note: If you are using a Jekyll version less than 3.5.0, use the `gems` key instead of `plugins`.
-
-## Publishing your site on GitHub Pages
-
-1.  If your created site is `YOUR-USERNAME/YOUR-SITE-NAME`, update `_config.yml` to:
-
-    ```yaml
-    title: YOUR TITLE
-    description: YOUR DESCRIPTION
-    theme: just-the-docs
-
-    url: https://YOUR-USERNAME.github.io/YOUR-SITE-NAME
-
-    aux_links: # remove if you don't want this link to appear on your pages
-      Template Repository: https://github.com/YOUR-USERNAME/YOUR-SITE-NAME
-    ```
-
-2.  Push your updated `_config.yml` to your site on GitHub.
-
-3.  In your newly created repo on GitHub:
-    - go to the `Settings` tab -> `Pages` -> `Build and deployment`, then select `Source`: `GitHub Actions`.
-    - if there were any failed Actions, go to the `Actions` tab and click on `Re-run jobs`.
-
-## Building and previewing your site locally
-
-Assuming [Jekyll] and [Bundler] are installed on your computer:
-
-1.  Change your working directory to the root directory of your site.
-
-2.  Run `bundle install`.
-
-3.  Run `bundle exec jekyll serve` to build your site and preview it at `localhost:4000`.
-
-    The built site is stored in the directory `_site`.
-
-## Publishing your built site on a different platform
-
-Just upload all the files in the directory `_site`.
-
-## Customization
-
-You're free to customize sites that you create with this template, however you like!
-
-[Browse our documentation][Just the Docs] to learn more about how to use this theme.
-
-## Hosting your docs from an existing project repo
-
-You might want to maintain your docs in an existing project repo. Instead of creating a new repo using the [just-the-docs template](https://github.com/just-the-docs/just-the-docs-template), you can copy the template files into your existing repo and configure the template's Github Actions workflow to build from a `docs` directory. You can clone the template to your local machine or download the `.zip` file to access the files.
-
-### Copy the template files
-
-1.  Create a `.github/workflows` directory at your project root if your repo doesn't already have one. Copy the `pages.yml` file into this directory. GitHub Actions searches this directory for workflow files.
-
-2.  Create a `docs` directory at your project root and copy all remaining template files into this directory.
-
-### Modify the GitHub Actions workflow
-
-The GitHub Actions workflow that builds and deploys your site to Github Pages is defined by the `pages.yml` file. You'll need to edit this file to that so that your build and deploy steps look to your `docs` directory, rather than the project root.
-
-1.  Set the default `working-directory` param for the build job.
-
-    ```yaml
-    build:
-      runs-on: ubuntu-latest
-      defaults:
-        run:
-          working-directory: docs
-    ```
-
-2.  Set the `working-directory` param for the Setup Ruby step.
-
-    ```yaml
-    - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-          bundler-cache: true
-          cache-version: 0
-          working-directory: '${{ github.workspace }}/docs'
-    ```
-
-3.  Set the path param for the Upload artifact step:
-
-    ```yaml
-    - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs/_site/
-    ```
-
-4.  Modify the trigger so that only changes within the `docs` directory start the workflow. Otherwise, every change to your project (even those that don't affect the docs) would trigger a new site build and deploy.
-
-    ```yaml
-    on:
-      push:
-        branches:
-          - "main"
-        paths:
-          - "docs/**"
-    ```
-
-## Licensing and Attribution
-
-This repository is licensed under the [MIT License]. You are generally free to reuse or extend upon this code as you see fit; just include the original copy of the license (which is preserved when you "make a template"). While it's not necessary, we'd love to hear from you if you do use this template, and how we can improve it for future use!
-
-The deployment GitHub Actions workflow is heavily based on GitHub's mixed-party [starter workflows]. A copy of their MIT License is available in [actions/starter-workflows].
-
-----
-
-[^1]: [It can take up to 10 minutes for changes to your site to publish after you push the changes to GitHub](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll#creating-your-site).
-
-[Jekyll]: https://jekyllrb.com
-[Just the Docs]: https://just-the-docs.github.io/just-the-docs/
-[GitHub Pages]: https://docs.github.com/en/pages
-[GitHub Pages / Actions workflow]: https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/
-[Bundler]: https://bundler.io
-[use this template]: https://github.com/just-the-docs/just-the-docs-template/generate
-[`jekyll-default-layout`]: https://github.com/benbalter/jekyll-default-layout
-[`jekyll-seo-tag`]: https://jekyll.github.io/jekyll-seo-tag
-[MIT License]: https://en.wikipedia.org/wiki/MIT_License
-[starter workflows]: https://github.com/actions/starter-workflows/blob/main/pages/jekyll.yml
-[actions/starter-workflows]: https://github.com/actions/starter-workflows/blob/main/LICENSE
+Released under the [MIT License](LICENSE). Built from the [just-the-docs template](https://github.com/just-the-docs/just-the-docs-template).

--- a/docs/Tutorials/VASP/Tutorial_2/index.md
+++ b/docs/Tutorials/VASP/Tutorial_2/index.md
@@ -14,16 +14,16 @@ In this section we will discus the inputs you need in order to run all the diffe
 As stated in [VASP Basics](../Tutorial_1/), the INCAR contains the set of instructions that tells VASP what type of  calculation to perform. Although we perform many different types of calculations, there are some standard parameters that we always use. Sometimes, we may choose to alter   the following parameters slightly, but for the vast majority of our calculations, these will remain constant.
 
 ```txt
-ALGO = Fast      # Mixture of Davidson and RMM-DIIS algos
-PREC = Normal         # Normal precision
-GGA_COMPAT = .False.    # Restore the full lattice symmetry of the GGA potential
-EDIFF = 1E-6     # Convergence criteria for electronic converge
-NELM = 500       # Max number of electronic steps
-ENCUT = 350      # Cut off energy
-LASPH = .True.     # Include non-spherical contributions from gradient corrections
-BMIX = 3         # Mixing parameter for convergence
-AMIN = 0.01      # Mixing parameter for convergence
-SIGMA = 0.05     # Width of smearing in eV
+ALGO       = Fast     # Mixture of Davidson and RMM-DIIS algos
+PREC       = Normal   # Normal precision
+GGA_COMPAT = .False.  # Restore the full lattice symmetry of the GGA potential
+EDIFF      = 1E-6     # Convergence criteria for electronic converge
+NELM       = 500      # Max number of electronic steps
+ENCUT      = 400      # Cut off energy
+LASPH      = .True.   # Include non-spherical contributions from gradient corrections
+BMIX       = 3        # Mixing parameter for convergence
+AMIN       = 0.01     # Mixing parameter for convergence
+SIGMA      = 0.05     # Width of smearing in eV
 ```
 
 > **About `EDIFF`.** From the [VASP wiki](https://www.vasp.at/wiki/index.php/EDIFF):
@@ -33,7 +33,7 @@ SIGMA = 0.05     # Width of smearing in eV
 > **About `NBANDS`.** We no longer set `NBANDS` and let VASP pick its default — `max( NELECT/2 + NIONS/2 , 0.6·NELECT )` (rounded up, with magnetism / non-collinear corrections applied automatically). Override it only when you need extra empty states (e.g. unfolded bands, GW, or to silence the "too few bands" warning at high SIGMA).
 
 ### POSCAR
-The POSCAR is the most user-dependent file in VASP and it defines the unit cell and exact location and element of each atom in the structure. For bulk structures, we typically get the initial structure file from <a href="https://materialsproject.org/" target="_blank">The Materials Project</a>. My preferred method is to just Google for my desired material (e.g. “InAs Materials Project”). Once you have the bulk structure, slabs or interfaces can be generated using either VaspVis or Ogre (our groups Python packages). More details about this with code examples will come later. The only calculations that require additional alterations to the POSCAR file are for an unfolded Band calculation and an OPT calculation
+The POSCAR is the most user-dependent file in VASP and it defines the unit cell and exact location and element of each atom in the structure. For bulk structures, we typically get the initial structure file from <a href="https://materialsproject.org/" target="_blank">The Materials Project</a>. My preferred method is to just Google for my desired material (e.g. “InAs Materials Project”). Once you have the bulk structure, slabs or interfaces can be generated using either [vaspvis](../../../Utilities/#vaspvis) or [OgreInterface](../../../Utilities/#ogreinterface) (our group's Python packages — see the [Utilities page](../../../Utilities/)). More details about this with code examples will come later. The only calculations that require additional alterations to the POSCAR file are for an unfolded Band calculation and an OPT calculation
 
 ### POTCAR
 The POTCAR is dependent on the elements used in the calculation and the order of the elements in the POSCAR. It is crucial that the order of the elements in the POTCAR match the order of the elements in the sixth line of the POSCAR. A POTCAR can be easily generated using the potcar.sh file. For example a common way to generate the POTCAR file is to use the head command to view the top lines of the POSCAR, and then use the potcar.sh file to generate the POTCAR file using the same elements shown in the 6th line of the POSCAR. To check the POTCAR you can use the grep command.
@@ -67,10 +67,10 @@ The SCF calculation will be used to generate converged CHG and CHGCAR files so t
 In the INCAR there are four important parameters beyond the general parameters. The one parameter that never changes is ICHARG=2 because the SCF calculation must calculate the charge density of the system. The other three parameters can change based on your needs. Sometimes we don’t need to write the CHG* files since we only need to do the SCF calculation, or sometimes we need the WAVECAR for STM simulations or wave function visualizations. Additionally, ISMEAR=0 is the standard parameter we used, but for certain materials a different smearing method might be necessary for convergence.
 
 ```txt
-ICHARG = 2 # Generate CHG* from a superposition of atomic charge densities
-ISMEAR = 0 # Fermi smearing
-LCHARG = .True. # Write the CHG* files
-LWAVE = .False. # Does not write the WAVECAR
+ICHARG = 2        # Generate CHG* from a superposition of atomic charge densities
+ISMEAR = 0        # Fermi smearing
+LCHARG = .True.   # Write the CHG* files
+LWAVE  = .False.  # Does not write the WAVECAR
 ```
 
 The following code can be used to generate the INCAR
@@ -103,14 +103,14 @@ kpoints.py -g -d 7 7 7
 In the INCAR there are eight important parameters beyond the general parameters. The only parameters that can be changed are NEDOS, EMIN, and EMAX. These values are used to determine the energy range to be calculated and how many points are included within the given energy range. By default, only 301 points are sampled for the density of states, and the energy range is unconstrained, so it includes the states with the lowest and highest energies. For the most part, we only care about a small range of energies around the Fermi energy, so we like to constrain the values between emin and emax.
 
 ```txt
-ICHARG = 11     # Calculate eigenvalues from preconverged CHGCAR
-ISMEAR = -5     # Tetrahedron method with Blochl corrections
+ICHARG = 11       # Calculate eigenvalues from preconverged CHGCAR
+ISMEAR = -5       # Tetrahedron method with Blochl corrections
 LCHARG = .False.  # Does not write the CHG* files
-LWAVE = .False.   # Does not write the WAVECAR files 
-LORBIT = 11     # Projected data (lm-decomposed PROCAR)
-NEDOS = 3001    # 3001 points are sampled for the DOS
-EMIN = emin     # Minimum energy for the DOS plot
-EMAX = emax     # Maximum energy for the DOS plot
+LWAVE  = .False.  # Does not write the WAVECAR files
+LORBIT = 11       # Projected data (lm-decomposed PROCAR)
+NEDOS  = 3001     # 3001 points are sampled for the DOS
+EMIN   = emin     # Minimum energy for the DOS plot
+EMAX   = emax     # Maximum energy for the DOS plot
 ```
 
 The actual values of emin and emax can be calculated manually by finding the Fermi energy from the OUTCAR of the SCF calculation and manually determining a range based on that value. For example, if it was only necessary to observe 3 eV above and below the Fermi energy, and the Fermi energy was -1 eV, then emin=-4 and emax=2 (Note that these are absolute energy values and not relative to the Fermi energy like how it is typically plotted). There is also a way to automate the determination of these values by adding the following lines of code to your submission script in your `scf` calculation.
@@ -147,11 +147,11 @@ kpoints.py -g -d 15 15 15
 In the INCAR there are five important parameters beyond the general parameters. The only parameters that can be changed are LWAVE and LORBIT. In the case of a calculation where it is desired to perform band unfolding the WAVECAR must be written (`LWAVE = .True.`). In the case where it is not important view the projected band structure (e.g. convergence tests) then the LORBIT tag can be removed.
 
 ```txt
-ICHARG = 11     # Calculate eigenvalues from preconverged CHGCAR
-ISMEAR = 0      # Fermi smearing
+ICHARG = 11       # Calculate eigenvalues from preconverged CHGCAR
+ISMEAR = 0        # Fermi smearing
 LCHARG = .False.  # Does not write the CHG* files
-LWAVE = .False.   # Does not write the WAVECAR file (.True. for unfolding)
-LORBIT = 11     # Projected data (lm-decomposed PROCAR)
+LWAVE  = .False.  # Does not write the WAVECAR file (.True. for unfolding)
+LORBIT = 11       # Projected data (lm-decomposed PROCAR)
 ```
 
 To generate the INCAR for a Band calculation the `incar.py` file can be used.
@@ -306,12 +306,12 @@ Structural optimization calculations are mostly used to relax atoms at a surface
 In the INCAR there are six important parameters beyond the general parameters. The first four parameters are essentially the same as an SCF calculation except for the fact that we typically do not write the CHG or CHGCAR files because we do not use them for anything after the OPT calculation in finished. The only parameter that can be changed is NSW which is the total number of ionic steps to be taken. Typically 50 ionic steps is more than enough, but is some cases this might need to be increased.
 
 ```txt
-ICHARG = 2      # Generate CHG* from a superposition of atomic charge densities
-ISMEAR = 0      # Fermi smearing
+ICHARG = 2        # Generate CHG* from a superposition of atomic charge densities
+ISMEAR = 0        # Fermi smearing
 LCHARG = .False.  # Does not write the CHG* files
-LWAVE = .False.   # Does not write the WAVECAR
-IBRION = 2      # Ionic relaxation
-NSW = 50        # Maximum of 50 ionic steps
+LWAVE  = .False.  # Does not write the WAVECAR
+IBRION = 2        # Ionic relaxation
+NSW    = 50       # Maximum of 50 ionic steps
 ```
 
 To generate the INCAR for a OPT calculation the incar.py file can be used.
@@ -351,18 +351,18 @@ direct
 ```
 
 ## Adding DFT+U to a Calculation
-Adding DFT+U is necessary for most calculations involving semiconductors because it corrects for the massive underestimate of the band gap with GGA. Our group has developed a method to predict the effective U value using Bayesian optimization by tuning the effective U parameters to best match the PBE+U band structure to the band structure calculated with HSE. A full example of how to run the Bayesian optimization code will be included in a following section for InAs.
+Adding DFT+U is necessary for most calculations involving semiconductors because it corrects for the massive underestimate of the band gap with GGA. Our group has developed a method to predict the effective U value using [Bayesian optimization](../../../Utilities/#bayesianopt4dftu) by tuning the effective U parameters to best match the PBE+U band structure to the band structure calculated with HSE. A full example of how to run the [BayesianOpt4dftu](../../../Utilities/#bayesianopt4dftu) code will be included in a following section for InAs.
 
 ### INCAR
 In the INCAR there are six important parameters beyond the general parameters. The only parameters that need to be changed are the ones for LDAUL, which determine the orbitals that the U value is applied, and LDAUU, which is where the actual effective U values are entered.
 
 ```txt
-LDAU = .True.       # Determines if DFT+U is used
-LDAUTYPE = 2      # Dudarev formulation
-LDAUL = 1 1       # l-quantum number to apply the U-value on (-1 turns it off)
-LDAUU = -0.5 -7.5 # Effective U-value for each species
-LDAUJ = 0.0 0.0   # J-value (Always zero for Dudarev method)
-LMAXMIX = 4       # Max l-quantum number for charge density mixing
+LDAU     = .True.     # Determines if DFT+U is used
+LDAUTYPE = 2          # Dudarev formulation
+LDAUL    = 1 1        # l-quantum number to apply the U-value on (-1 turns it off)
+LDAUU    = -0.5 -7.5  # Effective U-value for each species
+LDAUJ    = 0.0 0.0    # J-value (Always zero for Dudarev method)
+LMAXMIX  = 4          # Max l-quantum number for charge density mixing
 ```
 
 To generate the INCAR for a DFT+U calculation, the incar.py file can be used. Below is an example for generating an INCAR for an SCF calculation with DFT+U.
@@ -380,10 +380,10 @@ Adding spin orbit coupling is very important for most of the materials that we s
 In the INCAR there are two important parameters beyond the general parameters. The only parameter that needs to change is the `MAGMOM` parameter which defines the magnetic moment for each atom in the x, y, and z directions. The example shown below is for a bulk InAs calculation where there are only two atoms in the unit cell. Since both In and As have no magnetic moment, $m_x$, $m_y$, and $m_z$ are all 0.
 
 ```txt
-LSORBIT = .True.                    # Turn on spin-orbit coupling
-MAGMOM = 0 0 0 0 0 0  # Set the magnetic moment for each atom (3 for each atom)
+LSORBIT = .True.       # Turn on spin-orbit coupling
+MAGMOM  = 0 0 0 0 0 0  # Set the magnetic moment for each atom (3 for each atom)
 or
-MAGMOM = 6*0
+MAGMOM  = 6*0
 ```
 
 To generate the INCAR for an SOC calculation, the incar.py file can be used. Below is an example for generating an INCAR for an SCF calculation with SOC
@@ -395,26 +395,30 @@ incar.py -s -c
 ```
 
 ```txt
-# general 
-ALGO = Fast     # Mixture of Davidson and RMM-DIIS algos
-PREC = Normal        # Normal precision
-GGA_COMPAT = .False.   # Restore the full lattice symmetry of the GGA potential
-EDIFF = 1E-6    # Convergence criteria for electronic converge
-NELM = 500      # Max number of electronic steps
-ENCUT = 400     # Cut off energy
-LASPH = .True.    # Include non-spherical contributions from gradient corrections
-BMIX = 3        # Mixing parameter for convergence
-AMIN = 0.01     # Mixing parameter for convergence 
-SIGMA = 0.05    # Width of smearing in eV
+# --- general ---
+ALGO       = Fast     # Mixture of Davidson + RMM-DIIS
+PREC       = Normal   # Precision level
+EDIFF      = 1E-6     # Electronic SC break condition (VASP-wiki: 1E-6 is the best compromise)
+NELM       = 500      # Maximum number of electronic SCF steps
+ENCUT      = 400      # Plane-wave cutoff (eV)
+LASPH      = .True.   # Non-spherical contributions from gradient corrections
+GGA_COMPAT = .False.  # Restore full lattice symmetry (recommended; required for MAE)
+BMIX       = 3        # Mixing parameter for convergence
+AMIN       = 0.01     # Mixing parameter for convergence
+SIGMA      = 0.05     # Smearing width (eV)
 
-# parallelization
-KPAR = 8        # The number of k-points to be treated in parallel
-NCORE = 1        # Auto-reset to 1 by VASP when OpenMP is enabled
+# --- parallelisation (Perlmutter CPU defaults) ---
+KPAR       = 4        # k-points treated in parallel
+NCORE      = 1        # Auto-reset to 1 by VASP under OpenMP/GPU
 
-# scf 
-ICHARG = 2      # Generate CHG* from a superposition of atomic charge densities
-ISMEAR = 0      # Fermi smearing
-LCHARG = .True.   # Write the CHG* files
-LWAVE = .False.   # Does not write the WAVECAR
-LREAL = Auto    # Automatically chooses rea/reciprocal space for projections
+# --- SCF ---
+ICHARG     = 2        # Initial charge from atomic superposition
+ISMEAR     = 0        # Gaussian smearing for SCF
+LCHARG     = .True.   # Write CHG/CHGCAR for downstream PBE post-SCF (ICHARG = 11)
+LWAVE      = .False.  # Skip WAVECAR (PBE post-SCF reads CHGCAR via ICHARG = 11)
+LREAL      = .False.  # Reciprocal-space projectors (most accurate; fine for small cells)
+
+# --- spin-orbit coupling (use vasp_ncl) ---
+LSORBIT    = .True.   # Turn on spin-orbit coupling
+MAGMOM     = 6*0      # 3 components (mx my mz) per atom
 ```

--- a/docs/Tutorials/VASP/Tutorial_3/index.md
+++ b/docs/Tutorials/VASP/Tutorial_3/index.md
@@ -62,6 +62,20 @@ TITEL = PAW_PBE In 08Apr2002
 TITEL = PAW_PBE As 22Sep2009
 ```
 
+## Generating these inputs with VASPKIT
+
+Every helper-script step in this tutorial has a [VASPKIT](../../../Utilities/#vaspkit) equivalent — run it interactively (`vaspkit`, then type the number) or with the `-task` flag for scripting:
+
+| Step | Helper script | VASPKIT equivalent |
+|------|---------------|--------------------|
+| POTCAR | `potcar.sh In As` | `vaspkit -task 103` (recommended PAW — note it selects `In_d`) |
+| INCAR | `incar.py --scf` | `vaspkit -task 101` (choose the calculation type, then edit) |
+| SCF grid (7×7×7) | `kpoints.py -g -d 7 7 7` | `vaspkit -task 102 -kpr 0.04` |
+| DOS grid (15×15×15) | `kpoints.py -g -d 15 15 15` | `vaspkit -task 102 -kpr 0.019` |
+| Band k-path | `kpoints.py -b -c GXWLGK` | `vaspkit -task 303` → writes `KPATH.in`; rename to `KPOINTS` |
+
+Task 303 writes the full Setyawan-Curtarolo path `Γ–X–U | K–Γ–L–W–X`; keep the `Γ–X–W–L–Γ–K` segments this tutorial uses. The complete task list is on the [Utilities page](../../../Utilities/#vaspkit).
+
 ## Automation
 This entire calculation can be automated using a simple python script included below:
 ```python
@@ -150,28 +164,30 @@ incar.py -s
 This results in the following file.
 
 ```txt
-# general
-ALGO = Fast     # Mixture of Davidson and RMM-DIIS algos
-PREC = Normal        # Normal precision
-GGA_COMPAT = .False.   # Restore the full lattice symmetry of the GGA potential
-EDIFF = 1E-6    # Convergence criteria for electronic converge
-NELM = 500      # Max number of electronic steps
-ENCUT = 400     # Cut off energy
-LASPH = .True.    # Include non-spherical contributions from gradient corrections
-BMIX = 3        # Mixing parameter for convergence
-AMIN = 0.01     # Mixing parameter for convergence
-SIGMA = 0.05    # Width of smearing in eV
+# --- general ---
+ALGO       = Fast     # Mixture of Davidson + RMM-DIIS
+PREC       = Normal   # Precision level
+EDIFF      = 1E-6     # Electronic SC break condition (VASP-wiki: 1E-6 is the best compromise)
+NELM       = 500      # Maximum number of electronic SCF steps
+ENCUT      = 400      # Plane-wave cutoff (eV)
+LASPH      = .True.   # Non-spherical contributions from gradient corrections
+GGA_COMPAT = .False.  # Restore full lattice symmetry (recommended; required for MAE)
+BMIX       = 3        # Mixing parameter for convergence
+AMIN       = 0.01     # Mixing parameter for convergence
+SIGMA      = 0.05     # Smearing width (eV)
 
-# parallelization
-KPAR = 8        # The number of k-points to be treated in parallel
-NCORE = 1        # Auto-reset to 1 by VASP when OpenMP is enabled
+# --- parallelisation (Perlmutter CPU defaults) ---
+KPAR       = 4        # k-points treated in parallel
+NCORE      = 1        # Auto-reset to 1 by VASP under OpenMP/GPU
 
-# scf
-ICHARG = 2      # Generate CHG* from a superposition of atomic charge densities
-ISMEAR = 0      # Fermi smearing
-LCHARG = .True.   # Write the CHG* files
-LWAVE = .False.   # Does not write the WAVECAR
-LREAL = Auto    # Automatically chooses real/reciprocal space for projections
+# --- SCF ---
+ICHARG     = 2        # Initial charge from atomic superposition
+ISMEAR     = 0        # Gaussian smearing for SCF
+LCHARG     = .True.   # Write CHG/CHGCAR for downstream PBE post-SCF (ICHARG = 11)
+LWAVE      = .False.  # Skip WAVECAR (PBE post-SCF reads CHGCAR via ICHARG = 11)
+LREAL      = .False.  # Reciprocal-space projectors (most accurate; fine for small cells)
+
+# (Pure PBE; add --hse for HSE06 or --dftu for DFT+U)
 ```
 
 ## Density of States Calculation
@@ -189,31 +205,31 @@ incar.py -d
 Which results in the following file. The values of EMIN and EMAX were automatically  determined using the code shown in section [Calculation Descriptions](../Tutorial_2/).
 
 ```txt
-# general 
-ALGO = Fast     # Mixture of Davidson and RMM-DIIS algos
-PREC = Normal        # Normal precision
-GGA_COMPAT = .False.   # Restore the full lattice symmetry of the GGA potential
-EDIFF = 1E-6    # Convergence criteria for electronic converge
-NELM = 500      # Max number of electronic steps
-ENCUT = 400     # Cut off energy
-LASPH = .True.    # Include non-spherical contributions from gradient corrections
-BMIX = 3        # Mixing parameter for convergence
-AMIN = 0.01     # Mixing parameter for convergence 
-SIGMA = 0.05    # Width of smearing in eV
+# --- general ---
+ALGO       = Fast     # Mixture of Davidson + RMM-DIIS
+PREC       = Normal   # Precision level
+EDIFF      = 1E-6     # Electronic SC break condition (VASP-wiki: 1E-6 is the best compromise)
+NELM       = 500      # Maximum number of electronic SCF steps
+ENCUT      = 400      # Plane-wave cutoff (eV)
+LASPH      = .True.   # Non-spherical contributions from gradient corrections
+GGA_COMPAT = .False.  # Restore full lattice symmetry (recommended; required for MAE)
+BMIX       = 3        # Mixing parameter for convergence
+AMIN       = 0.01     # Mixing parameter for convergence
+SIGMA      = 0.05     # Smearing width (eV)
 
-# parallelization
-KPAR = 8        # The number of k-points to be treated in parallel
-NCORE = 1        # Auto-reset to 1 by VASP when OpenMP is enabled
+# --- parallelisation (Perlmutter CPU defaults) ---
+KPAR       = 4        # k-points treated in parallel
+NCORE      = 1        # Auto-reset to 1 by VASP under OpenMP/GPU
 
-# dos 
-ICHARG = 11     # Calculate eigenvalues from preconverged CHGCAR
-ISMEAR = -5     # Tetrahedron method with Blochl corrections
-LCHARG = .False.  # Does not write the CHG* files
-LWAVE = .False.   # Does not write the WAVECAR files 
-LORBIT = 11     # Projected data (lm-decomposed PROCAR)
-NEDOS = 3001    # 3001 points are sampled for the DOS
-EMIN = -3.7174     # Minimum energy for the DOS plot
-EMAX = 10.2826     # Maximum energy for the DOS plot
+# --- DOS ---
+ICHARG     = 11       # Read converged CHGCAR; non-SC eigenvalue calc
+ISMEAR     = -5       # Tetrahedron with Bloechl correction
+LCHARG     = .False.  # Do not write CHG/CHGCAR
+LWAVE      = .False.  # Do not write WAVECAR
+LORBIT     = 11       # lm-decomposed PROCAR / DOSCAR
+NEDOS      = 3001     # DOS sampling points
+EMIN       = -3.7174  # Filled in by sbatch script from SCF Fermi level
+EMAX       = 10.2826  # Filled in by sbatch script from SCF Fermi level
 ```
 
 ### KPOINTS
@@ -226,7 +242,7 @@ kpoints.py -g -d 15 15 15
 ```
 
 ### Results
-Once the calculation is finished, generate the DOS plots with [vaspvis](https://github.com/caizefeng/vaspvis):
+Once the calculation is finished, generate the DOS plots with [vaspvis](../../../Utilities/#vaspvis):
 
 ```python
 from vaspvis.standard import dos_plain, dos_spd
@@ -254,28 +270,28 @@ incar.py -b
 Which results in the following file:
 
 ```txt
-# general 
-ALGO = Fast     # Mixture of Davidson and RMM-DIIS algos
-PREC = Normal        # Normal precision
-GGA_COMPAT = .False.   # Restore the full lattice symmetry of the GGA potential
-EDIFF = 1E-6    # Convergence criteria for electronic converge
-NELM = 500      # Max number of electronic steps
-ENCUT = 400     # Cut off energy
-LASPH = .True.    # Include non-spherical contributions from gradient corrections
-BMIX = 3        # Mixing parameter for convergence
-AMIN = 0.01     # Mixing parameter for convergence 
-SIGMA = 0.05    # Width of smearing in eV
+# --- general ---
+ALGO       = Fast     # Mixture of Davidson + RMM-DIIS
+PREC       = Normal   # Precision level
+EDIFF      = 1E-6     # Electronic SC break condition (VASP-wiki: 1E-6 is the best compromise)
+NELM       = 500      # Maximum number of electronic SCF steps
+ENCUT      = 400      # Plane-wave cutoff (eV)
+LASPH      = .True.   # Non-spherical contributions from gradient corrections
+GGA_COMPAT = .False.  # Restore full lattice symmetry (recommended; required for MAE)
+BMIX       = 3        # Mixing parameter for convergence
+AMIN       = 0.01     # Mixing parameter for convergence
+SIGMA      = 0.05     # Smearing width (eV)
 
-# parallelization
-KPAR = 8        # The number of k-points to be treated in parallel
-NCORE = 1        # Auto-reset to 1 by VASP when OpenMP is enabled
+# --- parallelisation (Perlmutter CPU defaults) ---
+KPAR       = 4        # k-points treated in parallel
+NCORE      = 1        # Auto-reset to 1 by VASP under OpenMP/GPU
 
-# band 
-ICHARG = 11     # Calculate eigenvalues from preconverged CHGCAR
-ISMEAR = 0      # Fermi smearing
-LCHARG = .False.  # Does not write the CHG* files
-LWAVE = .False.   # Does not write the WAVECAR files (.True. for unfolding)
-LORBIT = 11     # Projected data (lm-decomposed PROCAR)
+# --- band ---
+ICHARG     = 11       # Read converged CHGCAR; non-SC band evaluation
+ISMEAR     = 0        # Gaussian smearing
+LCHARG     = .False.  # Do not write CHG/CHGCAR
+LWAVE      = .False.  # Do not write WAVECAR (.True. for unfolding)
+LORBIT     = 11       # lm-decomposed PROCAR
 ```
 
 ### KPOINTS

--- a/docs/Tutorials/VASP/Tutorial_4/index.md
+++ b/docs/Tutorials/VASP/Tutorial_4/index.md
@@ -62,6 +62,10 @@ TITEL = PAW_PBE In 08Apr2002
 TITEL = PAW_PBE As 22Sep2009
 ```
 
+## Generating these inputs with VASPKIT
+
+Same as the [PBE run](../Tutorial_3/#generating-these-inputs-with-vaspkit) — POTCAR `-task 103`, INCAR `-task 101`, grids `-task 102`, k-path `-task 303`. The one difference: VASPKIT's INCAR template does not add the spin-orbit tags, so append `LSORBIT = .True.` and `MAGMOM = 6*0` to the task-101 INCAR yourself (and run with `vasp_ncl`). See the [Utilities page](../../../Utilities/#vaspkit) for the full task list.
+
 ## Automation
 This entire calculation can be automated using a simple python script included below:
 ```python
@@ -150,32 +154,32 @@ incar.py -s -c
 This results in the following file.
 
 ```txt
-# general
-ALGO = Fast     # Mixture of Davidson and RMM-DIIS algos
-PREC = Normal        # Normal precision
-GGA_COMPAT = .False.   # Restore the full lattice symmetry of the GGA potential
-EDIFF = 1E-6    # Convergence criteria for electronic converge
-NELM = 500      # Max number of electronic steps
-ENCUT = 400     # Cut off energy
-LASPH = .True.    # Include non-spherical contributions from gradient corrections
-BMIX = 3        # Mixing parameter for convergence
-AMIN = 0.01     # Mixing parameter for convergence
-SIGMA = 0.05    # Width of smearing in eV
+# --- general ---
+ALGO       = Fast     # Mixture of Davidson + RMM-DIIS
+PREC       = Normal   # Precision level
+EDIFF      = 1E-6     # Electronic SC break condition (VASP-wiki: 1E-6 is the best compromise)
+NELM       = 500      # Maximum number of electronic SCF steps
+ENCUT      = 400      # Plane-wave cutoff (eV)
+LASPH      = .True.   # Non-spherical contributions from gradient corrections
+GGA_COMPAT = .False.  # Restore full lattice symmetry (recommended; required for MAE)
+BMIX       = 3        # Mixing parameter for convergence
+AMIN       = 0.01     # Mixing parameter for convergence
+SIGMA      = 0.05     # Smearing width (eV)
 
-# parallelization
-KPAR = 8        # The number of k-points to be treated in parallel
-NCORE = 1        # Auto-reset to 1 by VASP when OpenMP is enabled
+# --- parallelisation (Perlmutter CPU defaults) ---
+KPAR       = 4        # k-points treated in parallel
+NCORE      = 1        # Auto-reset to 1 by VASP under OpenMP/GPU
 
-# scf
-ICHARG = 2      # Generate CHG* from a superposition of atomic charge densities
-ISMEAR = 0      # Fermi smearing
-LCHARG = .True.   # Write the CHG* files
-LWAVE = .False.   # Does not write the WAVECAR
-LREAL = Auto    # Automatically chooses real/reciprocal space for projections
+# --- SCF ---
+ICHARG     = 2        # Initial charge from atomic superposition
+ISMEAR     = 0        # Gaussian smearing for SCF
+LCHARG     = .True.   # Write CHG/CHGCAR for downstream PBE post-SCF (ICHARG = 11)
+LWAVE      = .False.  # Skip WAVECAR (PBE post-SCF reads CHGCAR via ICHARG = 11)
+LREAL      = .False.  # Reciprocal-space projectors (most accurate; fine for small cells)
 
-# soc 
-LSORBIT = .True.  # Turn on spin-orbit coupling
-MAGMOM = 6*0 # Set the magnetic moment for each atom (3 for each atom)
+# --- spin-orbit coupling (use vasp_ncl) ---
+LSORBIT    = .True.   # Turn on spin-orbit coupling
+MAGMOM     = 6*0      # 3 components (mx my mz) per atom
 ```
 
 ## Density of States Calculation
@@ -193,35 +197,35 @@ incar.py -d -c
 Which results in the following file. The values of EMIN and EMAX were automatically  determined using the code shown in section [Calculation Descriptions](../Tutorial_2/).
 
 ```txt
-# general 
-ALGO = Fast     # Mixture of Davidson and RMM-DIIS algos
-PREC = Normal        # Normal precision
-GGA_COMPAT = .False.   # Restore the full lattice symmetry of the GGA potential
-EDIFF = 1E-6    # Convergence criteria for electronic converge
-NELM = 500      # Max number of electronic steps
-ENCUT = 400     # Cut off energy
-LASPH = .True.    # Include non-spherical contributions from gradient corrections
-BMIX = 3        # Mixing parameter for convergence
-AMIN = 0.01     # Mixing parameter for convergence 
-SIGMA = 0.05    # Width of smearing in eV
+# --- general ---
+ALGO       = Fast     # Mixture of Davidson + RMM-DIIS
+PREC       = Normal   # Precision level
+EDIFF      = 1E-6     # Electronic SC break condition (VASP-wiki: 1E-6 is the best compromise)
+NELM       = 500      # Maximum number of electronic SCF steps
+ENCUT      = 400      # Plane-wave cutoff (eV)
+LASPH      = .True.   # Non-spherical contributions from gradient corrections
+GGA_COMPAT = .False.  # Restore full lattice symmetry (recommended; required for MAE)
+BMIX       = 3        # Mixing parameter for convergence
+AMIN       = 0.01     # Mixing parameter for convergence
+SIGMA      = 0.05     # Smearing width (eV)
 
-# parallelization
-KPAR = 8        # The number of k-points to be treated in parallel
-NCORE = 1        # Auto-reset to 1 by VASP when OpenMP is enabled
+# --- parallelisation (Perlmutter CPU defaults) ---
+KPAR       = 4        # k-points treated in parallel
+NCORE      = 1        # Auto-reset to 1 by VASP under OpenMP/GPU
 
-# dos 
-ICHARG = 11     # Calculate eigenvalues from preconverged CHGCAR
-ISMEAR = -5     # Tetrahedron method with Blochl corrections
-LCHARG = .False.  # Does not write the CHG* files
-LWAVE = .False.   # Does not write the WAVECAR files 
-LORBIT = 11     # Projected data (lm-decomposed PROCAR)
-NEDOS = 3001    # 3001 points are sampled for the DOS
-EMIN = -3.7174     # Minimum energy for the DOS plot
-EMAX = 10.2826     # Maximum energy for the DOS plot
+# --- DOS ---
+ICHARG     = 11       # Read converged CHGCAR; non-SC eigenvalue calc
+ISMEAR     = -5       # Tetrahedron with Bloechl correction
+LCHARG     = .False.  # Do not write CHG/CHGCAR
+LWAVE      = .False.  # Do not write WAVECAR
+LORBIT     = 11       # lm-decomposed PROCAR / DOSCAR
+NEDOS      = 3001     # DOS sampling points
+EMIN       = -3.7174  # Filled in by sbatch script from SCF Fermi level
+EMAX       = 10.2826  # Filled in by sbatch script from SCF Fermi level
 
-# soc 
-LSORBIT = .True.  # Turn on spin-orbit coupling
-MAGMOM = 6*0 # Set the magnetic moment for each atom (3 for each atom)
+# --- spin-orbit coupling (use vasp_ncl) ---
+LSORBIT    = .True.   # Turn on spin-orbit coupling
+MAGMOM     = 6*0      # 3 components (mx my mz) per atom
 ```
 
 ### KPOINTS
@@ -234,7 +238,7 @@ kpoints.py -g -d 15 15 15
 ```
 
 ### Results
-Same vaspvis calls as the PBE run — the SOC weights are picked up automatically from the noncollinear `PROCAR`:
+Same [vaspvis](../../../Utilities/#vaspvis) calls as the PBE run — the SOC weights are picked up automatically from the noncollinear `PROCAR`:
 
 ```python
 from vaspvis.standard import dos_plain, dos_spd
@@ -260,32 +264,32 @@ incar.py -b -c
 Which results in the following file:
 
 ```txt
-# general 
-ALGO = Fast     # Mixture of Davidson and RMM-DIIS algos
-PREC = Normal        # Normal precision
-GGA_COMPAT = .False.   # Restore the full lattice symmetry of the GGA potential
-EDIFF = 1E-6    # Convergence criteria for electronic converge
-NELM = 500      # Max number of electronic steps
-ENCUT = 400     # Cut off energy
-LASPH = .True.    # Include non-spherical contributions from gradient corrections
-BMIX = 3        # Mixing parameter for convergence
-AMIN = 0.01     # Mixing parameter for convergence 
-SIGMA = 0.05    # Width of smearing in eV
+# --- general ---
+ALGO       = Fast     # Mixture of Davidson + RMM-DIIS
+PREC       = Normal   # Precision level
+EDIFF      = 1E-6     # Electronic SC break condition (VASP-wiki: 1E-6 is the best compromise)
+NELM       = 500      # Maximum number of electronic SCF steps
+ENCUT      = 400      # Plane-wave cutoff (eV)
+LASPH      = .True.   # Non-spherical contributions from gradient corrections
+GGA_COMPAT = .False.  # Restore full lattice symmetry (recommended; required for MAE)
+BMIX       = 3        # Mixing parameter for convergence
+AMIN       = 0.01     # Mixing parameter for convergence
+SIGMA      = 0.05     # Smearing width (eV)
 
-# parallelization
-KPAR = 8        # The number of k-points to be treated in parallel
-NCORE = 1        # Auto-reset to 1 by VASP when OpenMP is enabled
+# --- parallelisation (Perlmutter CPU defaults) ---
+KPAR       = 4        # k-points treated in parallel
+NCORE      = 1        # Auto-reset to 1 by VASP under OpenMP/GPU
 
-# band 
-ICHARG = 11     # Calculate eigenvalues from preconverged CHGCAR
-ISMEAR = 0      # Fermi smearing
-LCHARG = .False.  # Does not write the CHG* files
-LWAVE = .False.   # Does not write the WAVECAR files (.True. for unfolding)
-LORBIT = 11     # Projected data (lm-decomposed PROCAR)
+# --- band ---
+ICHARG     = 11       # Read converged CHGCAR; non-SC band evaluation
+ISMEAR     = 0        # Gaussian smearing
+LCHARG     = .False.  # Do not write CHG/CHGCAR
+LWAVE      = .False.  # Do not write WAVECAR (.True. for unfolding)
+LORBIT     = 11       # lm-decomposed PROCAR
 
-# soc 
-LSORBIT = .True.  # Turn on spin-orbit coupling
-MAGMOM = 6*0 # Set the magnetic moment for each atom (3 for each atom)
+# --- spin-orbit coupling (use vasp_ncl) ---
+LSORBIT    = .True.   # Turn on spin-orbit coupling
+MAGMOM     = 6*0      # 3 components (mx my mz) per atom
 ```
 
 ### KPOINTS

--- a/docs/Tutorials/VASP/Tutorial_5/index.md
+++ b/docs/Tutorials/VASP/Tutorial_5/index.md
@@ -63,6 +63,10 @@ TITEL = PAW_PBE In 08Apr2002
 TITEL = PAW_PBE As 22Sep2009
 ```
 
+## Generating these inputs with VASPKIT
+
+INCAR, POTCAR and the SCF grid are as in the [PBE run](../Tutorial_3/#generating-these-inputs-with-vaspkit) (add the HSE + SOC tags to the task-101 INCAR by hand). The HSE **band** KPOINTS is the special case: run `vaspkit -task 303` to write `KPATH.in`, then `vaspkit -task 251` to combine the SCF IBZKPT mesh with the zero-weight path — the same file `kpoints.py -b -c GXWLGK -e` produces. Extract/plot the hybrid band with `vaspkit -task 252` (the hybrid task — **not** 211). See the [Utilities page](../../../Utilities/#vaspkit) for the full task list.
+
 ## Automation
 This entire calculation can be automated using a simple python script included below. Two notes on KPOINTS:
 
@@ -156,38 +160,39 @@ incar.py -s -c -e
 This results in the following file.
 
 ```txt
-# general
-ALGO = Fast     # Mixture of Davidson and RMM-DIIS algos
-PREC = Normal        # Normal precision
-GGA_COMPAT = .False.   # Restore the full lattice symmetry of the GGA potential
-EDIFF = 1E-6    # Convergence criteria for electronic converge
-NELM = 500      # Max number of electronic steps
-ENCUT = 400     # Cut off energy
-LASPH = .True.    # Include non-spherical contributions from gradient corrections
-BMIX = 3        # Mixing parameter for convergence
-AMIN = 0.01     # Mixing parameter for convergence
-SIGMA = 0.05    # Width of smearing in eV
+# --- general ---
+ALGO       = All      # All-bands simultaneous update; robust for hybrids
+PREC       = Normal   # Precision level
+EDIFF      = 1E-6     # Electronic SC break condition (VASP-wiki: 1E-6 is the best compromise)
+NELM       = 500      # Maximum number of electronic SCF steps
+ENCUT      = 400      # Plane-wave cutoff (eV)
+LASPH      = .True.   # Non-spherical contributions from gradient corrections
+GGA_COMPAT = .False.  # Restore full lattice symmetry (recommended; required for MAE)
+BMIX       = 3        # Mixing parameter for convergence
+AMIN       = 0.01     # Mixing parameter for convergence
+SIGMA      = 0.05     # Smearing width (eV)
 
-# parallelization
-KPAR = 8        # The number of k-points to be treated in parallel
-NCORE = 1        # Auto-reset to 1 by VASP when OpenMP is enabled
+# --- parallelisation (Perlmutter CPU defaults) ---
+KPAR       = 16       # k-points treated in parallel
+NCORE      = 1        # Auto-reset to 1 by VASP under OpenMP/GPU
 
-# scf
-ICHARG = 2      # Generate CHG* from a superposition of atomic charge densities
-ISMEAR = 0      # Fermi smearing
-LCHARG = .True.   # Write the CHG* files
-LWAVE = .True.   # Write the WAVECAR (HSE post-SCF DOS reads it via ALGO = None)
-LREAL = Auto    # Automatically chooses real/reciprocal space for projections
+# --- SCF ---
+ICHARG     = 2        # Initial charge from atomic superposition
+ISMEAR     = 0        # Gaussian smearing for SCF
+LCHARG     = .True.   # Write CHG/CHGCAR for downstream PBE post-SCF (ICHARG = 11)
+LWAVE      = .True.   # Write WAVECAR (HSE post-SCF DOS reads it via ALGO = None)
+LREAL      = .False.  # Reciprocal-space projectors (most accurate; fine for small cells)
 
-# soc 
-LSORBIT = .True.  # Turn on spin-orbit coupling
-MAGMOM = 6*0 # Set the magnetic moment for each atom (3 for each atom)
+# --- spin-orbit coupling (use vasp_ncl) ---
+LSORBIT    = .True.   # Turn on spin-orbit coupling
+MAGMOM     = 6*0      # 3 components (mx my mz) per atom
 
-# hse 
-LHFCALC = .True.  # Determines if a hybrid functional is used
-HFSCREEN = 0.2  # Range-separation parameter
-AEXX = 0.25     # Fraction of exact exchange to be used
-PRECFOCK = Fast # Increases the speed of HSE Calculations
+# --- HSE06 hybrid functional ---
+LHFCALC    = .True.   # Turn on Hartree-Fock exchange
+HFSCREEN   = 0.2      # HSE06 range-separation parameter (1/Angstrom)
+AEXX       = 0.25     # Fraction of exact exchange (HSE06 standard)
+PRECFOCK   = Fast     # Reduced FFT mesh for the exchange routine
+TIME       = 0.4      # Trial time step for the ALGO = All band optimiser
 ```
 
 ## Density of States Calculation
@@ -205,39 +210,36 @@ incar.py -d -c -e
 Which results in the following file. The values of EMIN and EMAX were automatically  determined using the code shown in section [Calculation Descriptions](../Tutorial_2/). Note that `ALGO` and `NELM` are deliberately **not** in the general block here — `incar.py` deduplicates tags so the dos-block overrides (`ALGO = None`, `NELM = 1`) are the only ones written.
 
 ```txt
-# general 
-PREC = Normal        # Normal precision
-GGA_COMPAT = .False.   # Restore the full lattice symmetry of the GGA potential
-EDIFF = 1E-6    # Convergence criteria for electronic converge
-ENCUT = 400     # Cut off energy
-LASPH = .True.    # Include non-spherical contributions from gradient corrections
-BMIX = 3        # Mixing parameter for convergence
-AMIN = 0.01     # Mixing parameter for convergence 
-SIGMA = 0.05    # Width of smearing in eV
+# --- general ---
+PREC       = Normal   # Precision level
+EDIFF      = 1E-6     # Electronic SC break condition (VASP-wiki: 1E-6 is the best compromise)
+ENCUT      = 400      # Plane-wave cutoff (eV)
+LASPH      = .True.   # Non-spherical contributions from gradient corrections
+GGA_COMPAT = .False.  # Restore full lattice symmetry (recommended; required for MAE)
+BMIX       = 3        # Mixing parameter for convergence
+AMIN       = 0.01     # Mixing parameter for convergence
+SIGMA      = 0.05     # Smearing width (eV)
 
-# parallelization
-KPAR = 8        # The number of k-points to be treated in parallel
-NCORE = 1        # Auto-reset to 1 by VASP when OpenMP is enabled
+# --- parallelisation (Perlmutter CPU defaults) ---
+KPAR       = 16       # k-points treated in parallel
+NCORE      = 1        # Auto-reset to 1 by VASP under OpenMP/GPU
 
-# dos (post-process WAVECAR; HSE — no Fock exchange evaluated)
-ALGO = None     # Postprocess only: read orbitals + eigenvalues from WAVECAR
-NELM = 1        # No iteration (paired with ALGO = None)
-ISTART = 1      # Read WAVECAR
-ICHARG = 0      # Required for hybrids (never use ICHARG = 11 with HSE)
-ISMEAR = -5     # Tetrahedron method with Blochl corrections
-LCHARG = .False.  # Does not write the CHG* files
-LWAVE = .False.   # Does not write the WAVECAR
-LORBIT = 11     # Projected data (lm-decomposed PROCAR)
-NEDOS = 3001    # 3001 points are sampled for the DOS
-EMIN = -3.7174     # Minimum energy for the DOS plot
-EMAX = 10.2826     # Maximum energy for the DOS plot
+# --- DOS (post-process WAVECAR; HSE -- no Fock exchange evaluated) ---
+ALGO       = None     # Postprocess only: read orbitals + eigenvalues from WAVECAR
+NELM       = 1        # No iteration (paired with ALGO = None)
+ISTART     = 1        # Read WAVECAR
+ICHARG     = 0        # Required for hybrids (never use ICHARG = 11 with HSE)
+ISMEAR     = -5       # Tetrahedron with Bloechl correction
+LCHARG     = .False.  # Do not write CHG/CHGCAR
+LWAVE      = .False.  # Do not write WAVECAR
+LORBIT     = 11       # lm-decomposed PROCAR / DOSCAR
+NEDOS      = 3001     # DOS sampling points
+EMIN       = -3.7174  # Filled in by sbatch script from SCF Fermi level
+EMAX       = 10.2826  # Filled in by sbatch script from SCF Fermi level
 
-# soc 
-LSORBIT = .True.  # Turn on spin-orbit coupling
-MAGMOM = 6*0 # Set the magnetic moment for each atom (3 for each atom)
-
-# (no `# hse` block: ALGO = None doesn't evaluate the Fock operator,
-#  so LHFCALC / HFSCREEN / AEXX / PRECFOCK are unnecessary here)
+# --- spin-orbit coupling (use vasp_ncl) ---
+LSORBIT    = .True.   # Turn on spin-orbit coupling
+MAGMOM     = 6*0      # 3 components (mx my mz) per atom
 ```
 
 ### KPOINTS
@@ -248,7 +250,7 @@ cp ../scf/KPOINTS .
 ```
 
 ### Results
-vaspvis treats HSE the same as PBE — give it the `dos/` folder and let it parse `LHFCALC`:
+[vaspvis](../../../Utilities/#vaspvis) treats HSE the same as PBE — give it the `dos/` folder and let it parse `LHFCALC`:
 
 ```python
 from vaspvis.standard import dos_plain, dos_spd
@@ -274,39 +276,40 @@ incar.py -b -c -e
 Which results in the following file:
 
 ```txt
-# general 
-ALGO = Fast     # Mixture of Davidson and RMM-DIIS algos
-PREC = Normal        # Normal precision
-GGA_COMPAT = .False.   # Restore the full lattice symmetry of the GGA potential
-EDIFF = 1E-6    # Convergence criteria for electronic converge
-NELM = 500      # Max number of electronic steps
-ENCUT = 400     # Cut off energy
-LASPH = .True.    # Include non-spherical contributions from gradient corrections
-BMIX = 3        # Mixing parameter for convergence
-AMIN = 0.01     # Mixing parameter for convergence 
-SIGMA = 0.05    # Width of smearing in eV
+# --- general ---
+ALGO       = All      # All-bands simultaneous update; robust for hybrids
+PREC       = Normal   # Precision level
+EDIFF      = 1E-6     # Electronic SC break condition (VASP-wiki: 1E-6 is the best compromise)
+NELM       = 500      # Maximum number of electronic SCF steps
+ENCUT      = 400      # Plane-wave cutoff (eV)
+LASPH      = .True.   # Non-spherical contributions from gradient corrections
+GGA_COMPAT = .False.  # Restore full lattice symmetry (recommended; required for MAE)
+BMIX       = 3        # Mixing parameter for convergence
+AMIN       = 0.01     # Mixing parameter for convergence
+SIGMA      = 0.05     # Smearing width (eV)
 
-# parallelization
-KPAR = 8        # The number of k-points to be treated in parallel
-NCORE = 1        # Auto-reset to 1 by VASP when OpenMP is enabled
+# --- parallelisation (Perlmutter CPU defaults) ---
+KPAR       = 16       # k-points treated in parallel
+NCORE      = 1        # Auto-reset to 1 by VASP under OpenMP/GPU
 
-# band (HSE; restart from WAVECAR with zero-weight line k-points)
-ISTART = 1      # Read WAVECAR
-ICHARG = 0      # Required for hybrids; charge derived from orbitals
-ISMEAR = 0      # Fermi smearing
-LCHARG = .False.  # Does not write the CHG* files
-LWAVE = .False.   # Does not write the WAVECAR files (.True. for unfolding)
-LORBIT = 11     # Projected data (lm-decomposed PROCAR)
+# --- band (HSE; restart from WAVECAR with zero-weight line k-points) ---
+ISTART     = 1        # Read WAVECAR
+ICHARG     = 0        # Required for hybrids; charge derived from orbitals
+ISMEAR     = 0        # Gaussian smearing
+LCHARG     = .False.  # Do not write CHG/CHGCAR
+LWAVE      = .False.  # Do not write WAVECAR (.True. for unfolding)
+LORBIT     = 11       # lm-decomposed PROCAR
 
-# soc 
-LSORBIT = .True.  # Turn on spin-orbit coupling
-MAGMOM = 6*0 # Set the magnetic moment for each atom (3 for each atom)
+# --- spin-orbit coupling (use vasp_ncl) ---
+LSORBIT    = .True.   # Turn on spin-orbit coupling
+MAGMOM     = 6*0      # 3 components (mx my mz) per atom
 
-# hse 
-LHFCALC = .True.  # Determines if a hybrid functional is used
-HFSCREEN = 0.2  # Range-separation parameter
-AEXX = 0.25     # Fraction of exact exchange to be used
-PRECFOCK = Fast # Increases the speed of HSE Calculations
+# --- HSE06 hybrid functional ---
+LHFCALC    = .True.   # Turn on Hartree-Fock exchange
+HFSCREEN   = 0.2      # HSE06 range-separation parameter (1/Angstrom)
+AEXX       = 0.25     # Fraction of exact exchange (HSE06 standard)
+PRECFOCK   = Fast     # Reduced FFT mesh for the exchange routine
+TIME       = 0.4      # Trial time step for the ALGO = All band optimiser
 ```
 
 ### KPOINTS

--- a/docs/Tutorials/VASP/index.md
+++ b/docs/Tutorials/VASP/index.md
@@ -23,12 +23,13 @@ These tutorials introduce the VASP workflow used by the quantum-materials subgro
 1. You have a NERSC account and `vasp6` group access — see [HPC Onboard / Perlmutter](../../HPC%20Onboard/Perlmutter/).
 2. The helper scripts `incar.py`, `kpoints.py`, `potcar.sh` are on your `PATH`. Download them from the [Utilities page](../../Utilities/) and edit `potcar.sh` to point at your local `potpaw_PBE` repository — on Perlmutter use `/global/cfs/cdirs/m3578/shared_folder/Pseudopotentials/potpaw_PBE`.
 3. Optional but recommended:
-   - [VASPKIT](https://vaspkit.com/) — input-file generation and built-in band/DOS plotting. The official binary on the website is currently incompatible with Perlmutter's recent glibc upgrade, so use the 1.6.0 preview build staged on CFS. Copy it once into a location of your choice and add its `bin/` to your `PATH`:
+   - [VASPKIT](../../Utilities/#vaspkit) — input-file generation and built-in band/DOS plotting. The official binary on the website is linked against an older glibc and won't run on Perlmutter, so use the 1.6.0 preview build staged on CFS. Copy it once into a location of your choice and add its `bin/` to your `PATH`:
      ```bash
      cp -r /global/cfs/cdirs/m3578/shared_folder/vasp_tools/vaspkit.1.6.0 $HOME/opt/   # pick any install root you like
      echo 'export PATH="$HOME/opt/vaspkit.1.6.0/bin:$PATH"' >> ~/.bashrc
      source ~/.bashrc
      which vaspkit       # confirm it's on your PATH
      ```
-   - [vaspvis](https://github.com/caizefeng/vaspvis) — publication-quality band/DOS figures from the Python side.
-4. Install a structure viewer — [VESTA](https://jp-minerals.org/vesta/en/) is the easiest for VASP `POSCAR`/`CHGCAR`, [OVITO](https://www.ovito.org/) is good for trajectories.
+   - [vaspvis](../../Utilities/#vaspvis) — publication-quality band/DOS figures from the Python side.
+   - [OgreInterface](../../Utilities/#ogreinterface) — build slabs and epitaxial interfaces; [BayesianOpt4dftu](../../Utilities/#bayesianopt4dftu) — fit the DFT+U *U* to an HSE reference (used later in the series).
+4. Install a structure viewer — [VESTA](https://jp-minerals.org/vesta/en/) is the easiest for VASP `POSCAR`/`CHGCAR`, [OVITO](https://www.ovito.org/) is good for trajectories (both catalogued on the [Utilities page](../../Utilities/)).

--- a/docs/Utilities/index.md
+++ b/docs/Utilities/index.md
@@ -7,12 +7,14 @@ has_children: true
 
 # Utilities
 
-This section collects the tools and helper scripts that the tutorials reference. They fall into four buckets:
+This section collects the tools and helper scripts that the tutorials reference. They fall into these buckets:
 
 - **Automation platforms** — GIMS for FHI-aims, VASPKIT for VASP.
 - **Visualisation tools** — Jmol, OVITO, VESTA.
-- **Python libraries** — ASE and pymatgen for structure manipulation, DFT setup, and post-processing.
+- **Python libraries** — ASE and pymatgen for structure manipulation, DFT setup, and post-processing; `vaspvis` for VASP band/DOS figures.
+- **Marom-group QM packages** — OgreInterface (epitaxial interfaces) and BayesianOpt4dftu (DFT+U *U*-fitting).
 - **VASP helper scripts** — `incar.py`, `kpoints.py`, `potcar.sh` (used in the VASP tutorials).
+- **AI coding assistants** — Claude Code and OpenAI Codex for writing and extending workflow code.
 
 ---
 
@@ -34,35 +36,48 @@ GIMS is great for new users who want to skip manual setup, and for experienced u
 
 ### Installation
 
-1. Download the latest binary from [SourceForge](https://sourceforge.net/projects/vaspkit/files/).
-2. Add the binary to your `PATH`.
-3. Copy the bundled `how_to_set_environment_variable` to `~/.vaspkit` and edit the POTCAR paths inside.
+**General (non-Perlmutter):** download the latest binary from [SourceForge](https://sourceforge.net/projects/vaspkit/files/), add its `bin/` to your `PATH`, and copy the bundled `how_to_set_environment_variable` to `~/.vaspkit`, editing the POTCAR paths inside so tasks like 103/303 can find your PAW library.
 
 ```bash
 # typical .bashrc additions
 export PATH="$HOME/vaspkit/bin:$PATH"
 ```
 
+> ⚠️ **On Perlmutter, do _not_ use the SourceForge binary.** The version published on the website is linked against an older glibc and is incompatible with Perlmutter, so it fails to run. The **only** working build is the **1.6.0** copy staged on CFS under `shared_folder`. Install it once and edit `~/.vaspkit` for the POTCAR paths:
+
+```bash
+cp -r /global/cfs/cdirs/m3578/shared_folder/vasp_tools/vaspkit.1.6.0 $HOME/opt/   # pick any install root
+echo 'export PATH="$HOME/opt/vaspkit.1.6.0/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+which vaspkit       # confirm it's on your PATH
+```
+
 ### Most-used menus
 
-Run `vaspkit` and pick a numbered task — they all also accept the `-task <id>` flag for batch use.
+Run `vaspkit` and pick a numbered task interactively, or call it non-interactively for scripting — every task accepts the `-task <id>` flag:
+
+```bash
+vaspkit -task 102 -kpr 0.04     # Γ-centred grid at 0.04 (2π/Å) spacing → 7×7×7 for InAs
+```
 
 | Task | Purpose                                                                               |
 |------|---------------------------------------------------------------------------------------|
 | 101  | INCAR templates (static / relax / HSE / DFT+U / phonon …)                             |
-| 102  | KPOINTS — Monkhorst-Pack / Γ-centred grids                                            |
+| 102  | KPOINTS grid — Monkhorst-Pack / Γ-centred; set density with `-kpr <spacing>` (0.04 → 7×7×7, 0.019 → 15×15×15 for InAs) |
 | 103  | POTCAR (default recommended PAW)                                                      |
 | 104  | POTCAR (user-specified PAW per element)                                               |
-| 251  | **HSE band-structure KPOINTS** — auto-builds the IBZKPT + zero-weight path scheme     |
-| 303  | High-symmetry k-path along the Setyawan-Curtarolo convention (3D PBE band)            |
+| 303  | High-symmetry k-path, Setyawan-Curtarolo convention (3D PBE band) → writes `KPATH.in` |
 | 302  | High-symmetry k-path for 2D materials                                                 |
-| 211  | Plot PBE band structure from `EIGENVAL` / `vasprun.xml`                               |
-| 213  | Plot HSE band structure (handles the zero-weight points automatically)                |
-| 111  | Total / projected DOS                                                                 |
+| 251  | **HSE band-structure KPOINTS** — IBZKPT mesh + zero-weight path (reads `KPATH.in`)    |
+| 211  | Extract/plot PBE band structure from `EIGENVAL` / `vasprun.xml`                       |
+| 252  | Extract/plot **HSE** (hybrid) band structure — drops the zero-weight points automatically |
+| 111  | Total density of states (112–115 for projected DOS)                                  |
 | 911  | Band-gap finder                                                                       |
 | 912  | Effective-mass calculator                                                             |
 
-In the [VASP tutorials](../Tutorials/VASP/) we use VASPKIT mainly for tasks **102**, **251**, **303**, **211**, and **213**.
+In the [VASP tutorials](../Tutorials/VASP/) we use VASPKIT mainly for tasks **102**, **103**, **303**, **251**, **211**, and **252**. (Task IDs verified against VASPKIT 1.6.0 — note 252, not 213, is the hybrid-band task.)
+
+> Please cite VASPKIT if you use it: V. Wang *et al.*, *Comput. Phys. Commun.* **267**, 108033 (2021); W.T. Geng *et al.*, *Nat. Protoc.* **20**, 3143 (2025).
 
 ---
 
@@ -108,6 +123,7 @@ pip install pymatgen
 ```
 
 ### 🔸 [vaspvis](https://github.com/caizefeng/vaspvis)
+{: #vaspvis }
 - Python plotting toolkit for VASP band structures, DOS, and band-unfolding.
 - Wraps a clean object-oriented API around `vasprun.xml` / `EIGENVAL` / `PROCAR`, including correct handling of HSE zero-weight k-points and slab/supercell unfolding.
 - Used in the [VASP tutorials](../Tutorials/VASP/) for the publication-quality figures.
@@ -126,6 +142,32 @@ bs.plot_plain(output="InAs_band.png")
 ```
 
 For HSE bands (Tutorial 5) the same call works because `vaspvis` reads the IBZKPT-augmented KPOINTS from the run folder and drops the weighted points automatically.
+
+---
+
+## Marom-group QM packages
+
+Two Python packages from the group are central to inorganic (quantum-materials) work and appear in the workflow around the [VASP tutorials](../Tutorials/VASP/).
+
+### 🔸 [OgreInterface](https://github.com/DerekDardzinski/OgreInterface)
+{: #ogreinterface }
+- Builds and optimises **lattice- and domain-matched epitaxial interfaces** between inorganic crystals (Marom group, Derek Dardzinski).
+- Scans substrate/film Miller-index combinations for the lowest-mismatch interfaces, then uses Bayesian *surface matching* to find the optimal interfacial distance and in-plane registry.
+- The inorganic counterpart to Ogre (organic molecular-crystal surfaces); also ships a desktop GUI. Use it to generate the slabs/interfaces you then feed to VASP.
+
+```bash
+pip install OgreInterface
+```
+
+### 🔸 [BayesianOpt4dftu](https://github.com/caizefeng/BayesianOpt4dftu)
+{: #bayesianopt4dftu }
+- Determines the Hubbard **U** for DFT+U by **Bayesian optimisation**, tuning U so the PBE+U band structure matches an HSE06 (or experimental) reference — the exact method described in the [DFT+U section of Tutorial 2](../Tutorials/VASP/Tutorial_2/#adding-dftu-to-a-calculation).
+- Drives VASP automatically and reports the optimal U together with the Gaussian-process mean and acquisition surface.
+- Active, refactored version maintained in the group; original at [maituoy/BayesianOpt4dftu](https://github.com/maituoy/BayesianOpt4dftu). Method: M. Yu, S. Yang, C. Wu & N. Marom, *npj Comput. Mater.* **6**, 180 (2020).
+
+```bash
+pip install BayesOpt4dftu
+```
 
 ---
 
@@ -153,3 +195,14 @@ echo 'export PATH=$HOME/bin:$PATH' >> ~/.bashrc
 > Both `incar.py --help` and `kpoints.py --help` list every flag. Edit `potcar.sh` once to point at your `potpaw_PBE` directory; on Perlmutter the group typically keeps it under `/global/common/software/<repo>/`.
 
 > The Marom-group VASP scripts and the FHI-aims tutorial helpers (`write_control.py`, `Automation.py`, `Surfaces.py`, `aimsplot.py`) are conceptually similar — they wrap argparse around the parts of the workflow that don't change. Use VASPKIT when you want a richer interactive menu.
+
+---
+
+## AI coding assistants
+
+Research involves a lot of glue code — generating inputs, parsing `OUTCAR` / `vasprun.xml`, batching jobs, plotting. Terminal-based AI coding assistants speed this up and run fine on the Perlmutter **login node**:
+
+- **[Claude Code](https://claude.com/claude-code)** — Anthropic's agentic CLI (`claude`). Good for writing and debugging analysis scripts, extending the helper scripts (`incar.py`, `kpoints.py`), wrangling Slurm submit scripts, and explaining VASP errors. Also available in VS Code / JetBrains and on the web.
+- **[OpenAI Codex CLI](https://github.com/openai/codex)** — a comparable terminal agent (`codex`).
+
+Use them to *understand and extend* the workflow, not to skip learning it — the [goal of these tutorials](../) is for you to own the logic, the physics, and the pipeline yourself. Treat generated code like a colleague's: read it, test it, and sanity-check the physics before trusting a number.

--- a/docs/Utilities/scripts/incar.py
+++ b/docs/Utilities/scripts/incar.py
@@ -21,10 +21,16 @@ Defaults (always written; based on VASP-wiki recommendations)
   GGA_COMPAT   = .False.     # restore full Bravais-lattice symmetry of the
                              # gradient field; default of .True. only exists
                              # for backward compatibility.
+  ALGO         = Fast        # Davidson + RMM-DIIS for PBE; automatically
+                             # switched to ALGO = All for HSE (--hse), which is
+                             # the robust all-bands optimiser for hybrids.
   NBANDS       --            # NOT written. VASP's default
                              # max( (NELECT+2)/2 + max(NIONS/2, 3), 0.6*NELECT )
                              # is fine for the systems used in these tutorials;
                              # SOC doubles it internally.
+
+The output is column-aligned: every "=" lines up, and every inline "#" comment
+lines up, so the generated INCAR matches the blocks shown in the tutorials.
 """
 
 import argparse
@@ -35,7 +41,7 @@ import textwrap
 
 # Drop any tag that gets set more than once, keeping only the last occurrence.
 # VASP uses last-wins semantics, but echoing the override on top of the
-# original value clutters the INCAR (e.g. ALGO = Fast in the general block
+# original value clutters the INCAR (e.g. ALGO = All in the general block
 # followed by ALGO = None in a HSE-DOS block).
 _TAG_RE = re.compile(r"^\s*([A-Za-z][A-Za-z0-9_]*)\s*=")
 
@@ -44,6 +50,8 @@ def _deduplicate_tags(text):
     lines = text.splitlines()
     occurrences = {}
     for i, line in enumerate(lines):
+        if line.lstrip().startswith("#"):
+            continue
         m = _TAG_RE.match(line)
         if m:
             occurrences.setdefault(m.group(1).upper(), []).append(i)
@@ -51,126 +59,173 @@ def _deduplicate_tags(text):
     return "\n".join(line for i, line in enumerate(lines) if i not in drop)
 
 
-# --- INCAR fragments ---------------------------------------------------------
-GENERAL = """\
-# --- general -----------------------------------------------------------------
-ALGO       = Fast        # Mixture of Davidson + RMM-DIIS
-PREC       = Normal      # Precision level
-EDIFF      = {ediff}     # Electronic SC break condition (VASP-wiki: 1E-6 is the best compromise)
-NELM       = 500         # Maximum number of electronic SCF steps
-ENCUT      = {encut}     # Plane-wave cutoff (eV)
-LASPH      = .True.      # Non-spherical contributions from gradient corrections
-GGA_COMPAT = .False.     # Restore full lattice symmetry (recommended; required for MAE)
-BMIX       = 3           # Mixing parameter for convergence
-AMIN       = 0.01        # Mixing parameter for convergence
-SIGMA      = 0.05        # Smearing width (eV)
+# Align every "TAG = value  # comment" line: pad the tag so all "=" line up,
+# pad the value so all inline "#" line up. Comment text is therefore left-
+# aligned with respect to a single "#" column across the whole file.
+_TAGLINE_RE = re.compile(r"^\s*([A-Za-z][A-Za-z0-9_]*)\s*=(.*)$")
 
-# --- parallelisation (Perlmutter 1-node CPU defaults) ------------------------
-KPAR       = {kpar}      # k-point parallelism
-NCORE      = {ncore}     # MPI ranks collaborating on one band; ~sqrt(ranks per k-group)
+
+def _format_incar(text):
+    parsed, tag_w, val_w = [], 0, 0
+    for line in text.splitlines():
+        m = _TAGLINE_RE.match(line)
+        if m and not line.lstrip().startswith("#"):
+            tag, rest = m.group(1), m.group(2)
+            if "#" in rest:
+                value, comment = rest.split("#", 1)
+                value, comment = value.strip(), comment.strip()
+            else:
+                value, comment = rest.strip(), None
+            parsed.append(("tag", tag, value, comment))
+            tag_w = max(tag_w, len(tag))
+            if comment is not None:
+                val_w = max(val_w, len(value))
+        else:
+            parsed.append(("raw", line))
+
+    out = []
+    for item in parsed:
+        if item[0] == "raw":
+            out.append(item[1])
+            continue
+        _, tag, value, comment = item
+        if comment is None:
+            out.append(f"{tag:<{tag_w}} = {value}")
+        else:
+            out.append(f"{tag:<{tag_w}} = {value:<{val_w}}  # {comment}")
+    return "\n".join(out)
+
+
+# --- INCAR fragments ---------------------------------------------------------
+# Written with single-space padding; _format_incar aligns them on output.
+GENERAL = """\
+# --- general ---
+ALGO = {algo}  # {algo_comment}
+PREC = Normal  # Precision level
+EDIFF = {ediff}  # Electronic SC break condition (VASP-wiki: 1E-6 is the best compromise)
+NELM = 500  # Maximum number of electronic SCF steps
+ENCUT = {encut}  # Plane-wave cutoff (eV)
+LASPH = .True.  # Non-spherical contributions from gradient corrections
+GGA_COMPAT = .False.  # Restore full lattice symmetry (recommended; required for MAE)
+BMIX = 3  # Mixing parameter for convergence
+AMIN = 0.01  # Mixing parameter for convergence
+SIGMA = 0.05  # Smearing width (eV)
+
+# --- parallelisation (Perlmutter CPU defaults) ---
+KPAR = {kpar}  # k-points treated in parallel
+NCORE = {ncore}  # Auto-reset to 1 by VASP under OpenMP/GPU
 """
 
 SCF = """\
-# --- SCF ---------------------------------------------------------------------
-ICHARG = 2               # Initial charge from atomic superposition
-ISMEAR = 0               # Gaussian smearing for SCF
-LCHARG = .True.          # Write CHG/CHGCAR for downstream PBE post-SCF (ICHARG = 11)
-LWAVE  = {lwave}         # {lwave_comment}
-LREAL  = Auto            # Automatically chooses real/reciprocal projections
+# --- SCF ---
+ICHARG = 2  # Initial charge from atomic superposition
+ISMEAR = 0  # Gaussian smearing for SCF
+LCHARG = .True.  # Write CHG/CHGCAR for downstream PBE post-SCF (ICHARG = 11)
+LWAVE = {lwave}  # {lwave_comment}
+LREAL = .False.  # Reciprocal-space projectors (most accurate; fine for small cells)
 """
 
 DOS = """\
-# --- DOS ---------------------------------------------------------------------
-ICHARG = 11              # Read converged CHGCAR; non-SC eigenvalue calc
-ISMEAR = -5              # Tetrahedron with Bloechl correction
-LCHARG = .False.
-LWAVE  = .False.
-LORBIT = 11              # lm-decomposed PROCAR / DOSCAR
-NEDOS  = 3001
-EMIN   = emin            # Filled in by sbatch script from SCF Fermi level
-EMAX   = emax
+# --- DOS ---
+ICHARG = 11  # Read converged CHGCAR; non-SC eigenvalue calc
+ISMEAR = -5  # Tetrahedron with Bloechl correction
+LCHARG = .False.  # Do not write CHG/CHGCAR
+LWAVE = .False.  # Do not write WAVECAR
+LORBIT = 11  # lm-decomposed PROCAR / DOSCAR
+NEDOS = 3001  # DOS sampling points
+EMIN = emin  # Filled in by sbatch script from SCF Fermi level
+EMAX = emax  # Filled in by sbatch script from SCF Fermi level
 """
 
 # HSE DOS: ALGO = None just reads orbitals/eigenvalues from WAVECAR (VASP wiki:
 # IALGO = 2). No Hamiltonian is evaluated, so no LHFCALC/HFSCREEN/AEXX needed.
 # The DOS k-mesh therefore equals the SCF k-mesh (whatever WAVECAR holds).
 DOS_HSE = """\
-# --- DOS (post-process WAVECAR; HSE) ----------------------------------------
-ALGO   = None            # Postprocess only: read orbitals + eigenvalues from WAVECAR
-NELM   = 1               # No iteration (paired with ALGO = None)
-ISTART = 1               # Read WAVECAR
-ICHARG = 0               # Required for hybrids (never use ICHARG = 11 with HSE)
-ISMEAR = -5              # Tetrahedron with Bloechl correction
-LCHARG = .False.
-LWAVE  = .False.
-LORBIT = 11              # lm-decomposed PROCAR / DOSCAR
-NEDOS  = 3001
-EMIN   = emin            # Filled in by sbatch script from SCF Fermi level
-EMAX   = emax
+# --- DOS (post-process WAVECAR; HSE -- no Fock exchange evaluated) ---
+ALGO = None  # Postprocess only: read orbitals + eigenvalues from WAVECAR
+NELM = 1  # No iteration (paired with ALGO = None)
+ISTART = 1  # Read WAVECAR
+ICHARG = 0  # Required for hybrids (never use ICHARG = 11 with HSE)
+ISMEAR = -5  # Tetrahedron with Bloechl correction
+LCHARG = .False.  # Do not write CHG/CHGCAR
+LWAVE = .False.  # Do not write WAVECAR
+LORBIT = 11  # lm-decomposed PROCAR / DOSCAR
+NEDOS = 3001  # DOS sampling points
+EMIN = emin  # Filled in by sbatch script from SCF Fermi level
+EMAX = emax  # Filled in by sbatch script from SCF Fermi level
 """
 
 BAND = """\
-# --- band --------------------------------------------------------------------
-ICHARG = 11              # Read converged CHGCAR; non-SC band evaluation
-ISMEAR = 0               # Gaussian smearing
-LCHARG = .False.
-LWAVE  = .False.
-LORBIT = 11              # lm-decomposed PROCAR
+# --- band ---
+ICHARG = 11  # Read converged CHGCAR; non-SC band evaluation
+ISMEAR = 0  # Gaussian smearing
+LCHARG = .False.  # Do not write CHG/CHGCAR
+LWAVE = .False.  # Do not write WAVECAR (.True. for unfolding)
+LORBIT = 11  # lm-decomposed PROCAR
 """
 
 # HSE band: KPOINTS file is SCF IBZKPT + line k-points with weight 0.
-# ALGO = Fast iterates over the new line k-points using the converged orbitals
-# at the SCF k-points (read via ISTART = 1) as starting guess. ICHARG = 11
-# is forbidden for hybrids.
+# ALGO = All (set in the general block) iterates over the new line k-points
+# using the converged orbitals read from WAVECAR (ISTART = 1) as the starting
+# guess. ICHARG = 11 is forbidden for hybrids.
 BAND_HSE = """\
-# --- band (HSE; restart from WAVECAR with zero-weight line k-points) ---------
-ISTART = 1               # Read WAVECAR
-ICHARG = 0               # Required for hybrids; charge derived from orbitals
-ISMEAR = 0               # Gaussian smearing
-LCHARG = .False.
-LWAVE  = .False.
-LORBIT = 11              # lm-decomposed PROCAR
+# --- band (HSE; restart from WAVECAR with zero-weight line k-points) ---
+ISTART = 1  # Read WAVECAR
+ICHARG = 0  # Required for hybrids; charge derived from orbitals
+ISMEAR = 0  # Gaussian smearing
+LCHARG = .False.  # Do not write CHG/CHGCAR
+LWAVE = .False.  # Do not write WAVECAR (.True. for unfolding)
+LORBIT = 11  # lm-decomposed PROCAR
 """
 
 OPT = """\
-# --- optimisation ------------------------------------------------------------
-ICHARG = 2
-ISMEAR = 0
-LCHARG = .False.
-LWAVE  = .False.
-IBRION = 2               # Conjugate-gradient ionic relaxation
-NSW    = 50              # Maximum ionic steps
+# --- optimisation ---
+ICHARG = 2  # Initial charge from atomic superposition
+ISMEAR = 0  # Gaussian smearing
+LCHARG = .False.  # Do not write CHG/CHGCAR
+LWAVE = .False.  # Do not write WAVECAR
+IBRION = 2  # Conjugate-gradient ionic relaxation
+NSW = 50  # Maximum ionic steps
 """
 
 SOC = """\
-# --- spin-orbit coupling -----------------------------------------------------
-LSORBIT = .True.         # Use vasp_ncl for this calculation
-MAGMOM  = {magmom}       # 3 components per atom
+# --- spin-orbit coupling (use vasp_ncl) ---
+LSORBIT = .True.  # Turn on spin-orbit coupling
+MAGMOM = {magmom}  # 3 components (mx my mz) per atom
 """
 
 DFTU = """\
-# --- DFT+U (Dudarev simplified) ---------------------------------------------
-LDAU     = .True.
-LDAUTYPE = 2             # Dudarev formulation (only U_eff = U - J matters)
-LDAUL    = {ldaul}       # l-quantum number per species (-1 = off)
-LDAUU    = {ldauu}       # Effective U per species
-LDAUJ    = {ldauj}
-LMAXMIX  = 4             # 4 for d, 6 for f
+# --- DFT+U (Dudarev) ---
+LDAU = .True.  # Turn on DFT+U
+LDAUTYPE = 2  # Dudarev formulation (only U_eff = U - J matters)
+LDAUL = {ldaul}  # l-quantum number per species (-1 = off)
+LDAUU = {ldauu}  # Effective U per species
+LDAUJ = {ldauj}  # Always 0 for Dudarev
+LMAXMIX = 4  # 4 for d electrons, 6 for f
 """
 
+# HSE block: ALGO is set to All in the general block above, so it is NOT
+# repeated here. TIME is the trial step used by the ALGO = All optimiser.
 HSE = """\
-# --- HSE06 hybrid functional -------------------------------------------------
-LHFCALC  = .True.        # Turn on Hartree-Fock exchange
-HFSCREEN = 0.2           # HSE06 range-separation parameter (1/A)
-AEXX     = 0.25          # Fraction of exact exchange (HSE06 standard)
-PRECFOCK = Fast          # Reduced FFT mesh for the exchange routine
-TIME     = 0.4           # Damping time-step for ALGO = Damped
+# --- HSE06 hybrid functional ---
+LHFCALC = .True.  # Turn on Hartree-Fock exchange
+HFSCREEN = 0.2  # HSE06 range-separation parameter (1/Angstrom)
+AEXX = 0.25  # Fraction of exact exchange (HSE06 standard)
+PRECFOCK = Fast  # Reduced FFT mesh for the exchange routine
+TIME = 0.4  # Trial time step for the ALGO = All band optimiser
 """
 
 
 # --- driver ------------------------------------------------------------------
 def build_incar(args):
+    # HSE uses the robust all-bands optimiser; PBE uses Davidson + RMM-DIIS.
+    if args.hse:
+        algo, algo_comment = "All", "All-bands simultaneous update; robust for hybrids"
+    else:
+        algo, algo_comment = "Fast", "Mixture of Davidson + RMM-DIIS"
+
     parts = [GENERAL.format(
+        algo=algo, algo_comment=algo_comment,
         ediff=args.ediff, encut=args.encut,
         kpar=args.kpar, ncore=args.ncore,
     )]
@@ -211,14 +266,12 @@ def build_incar(args):
     if args.hse:
         # SCF and band evaluate the HF exchange operator and need the HSE block.
         # DOS uses ALGO = None (no Hamiltonian eval), so HSE tags are unnecessary.
-        if args.dos:
-            pass
-        else:
+        if not args.dos:
             parts.append(HSE)
-    elif main in ("scf", "opt"):
+    elif main in ("scf", "opt") and not (args.soc or args.dftu):
         parts.append("# (Pure PBE; add --hse for HSE06 or --dftu for DFT+U)\n")
 
-    return _deduplicate_tags("\n".join(parts))
+    return _format_incar(_deduplicate_tags("\n".join(parts)))
 
 
 def _default_magmom(poscar_path):
@@ -251,7 +304,7 @@ def parse_args():
     m.add_argument("-c", "--soc",  action="store_true",
                    help="Add spin-orbit (use vasp_ncl).")
     m.add_argument("-e", "--hse",  action="store_true",
-                   help="Add HSE06 hybrid block.")
+                   help="Add HSE06 hybrid block (also sets ALGO = All).")
     m.add_argument("-u", "--dftu", action="store_true",
                    help="Add Dudarev DFT+U block.")
 
@@ -280,5 +333,5 @@ if __name__ == "__main__":
     args = parse_args()
     text = build_incar(args)
     with open(args.output, "w") as fh:
-        fh.write(text)
+        fh.write(text + "\n")
     print(f"Wrote {args.output} ({len(text.splitlines())} lines).")

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,29 +5,46 @@ nav_order: 1            # 2,3,4 for the others
 has_children: true
 ---
 
-Welcome to the Basic Training Document for Noa Marom's Research Group
+# Basic Training — Noa Marom Research Group
 
-This guide provides essential tutorials and utility scripts to help you get started.
-Before beginning your training journey, please:
+**The goal of this training is not to memorise a fixed recipe.** It is to help you understand the *workflow*, the *programming logic*, and the *underlying physics* well enough to carry out independent research — on new systems, with new techniques (new functionals, new corrections), and with analysis pipelines you implement yourself. The tutorials walk through concrete calculations, but treat every script and input file as something to read, question, and eventually rewrite for your own problem.
 
-1. **Download** all the necessary files here:
+Pick the track that matches your project:
+
+---
+
+## 🧪 Organic / molecular materials
+
+*(CSP, GATOR, Organic Interface, singlet-fission (SF) subgroups.)* These projects use the all-electron code **FHI-aims** on **Trace** or **Arjuna**.
+
+1. **Download** the tutorial files:
    👉 <a href="Tutorials_files.zip" download>📥 Download Tutorial Files</a>
 
-2. **Unzip and add the directory to your HPC, then enter it:**
+2. **Unzip, copy to your HPC, and enter the directory:**
    ```bash
    cd Tutorials_files
    ```
-2. **Run the setup script** to configure your environment:
-   - If you are on Trace:
-     ```bash
-     bash setup_utils.sh trace
-     ```
-   - If you are on Arjuna:
-     ```bash
-     bash setup_utils.sh arjuna
-     ```
 
-If you are doing the VASP tutorials instead, follow the [Perlmutter onboarding](HPC%20Onboard/Perlmutter/) and the [VASP tutorials](Tutorials/VASP/) — `setup_utils.sh` only covers the FHI-aims tooling.
+3. **Run the setup script** to install the FHI-aims helper scripts (`write_control.py`, `Automation.py`, `Surfaces.py`, `aimsplot.py`, `submit.sh`) into your `~`:
+   - On Trace:&nbsp;&nbsp;`bash setup_utils.sh trace`
+   - On Arjuna: `bash setup_utils.sh arjuna`
 
+4. Work through the [FHI-aims tutorials](Tutorials/FHI-aims/) — H₂ → periodic solids → 2D/surfaces.
 
+New to the clusters? Start with [HPC Onboard](HPC%20Onboard/) for Trace/Arjuna, Linux, Slurm, and Python environments.
 
+---
+
+## 💎 Inorganic / quantum materials
+
+*(Quantum-materials (QM) subgroup.)* These projects use the plane-wave + PAW code **VASP** on **NERSC Perlmutter**.
+
+1. **Get access:** a NERSC account in the `m3578` allocation and the `vasp6` Unix group — see the [Perlmutter onboarding](HPC%20Onboard/Perlmutter/).
+
+2. **Install the VASP helper scripts** `incar.py`, `kpoints.py`, `potcar.sh` from the [Utilities page](Utilities/), and point `potcar.sh` at `/global/cfs/cdirs/m3578/shared_folder/Pseudopotentials/potpaw_PBE`.
+
+3. **Install the supporting tools** (all on the [Utilities page](Utilities/)): [VASPKIT](Utilities/#vaspkit) for input generation and post-processing, [vaspvis](Utilities/#vaspvis) for figures, and the group's QM packages [OgreInterface](Utilities/#ogreinterface) (slabs/interfaces) and [BayesianOpt4dftu](Utilities/#bayesianopt4dftu) (DFT+U *U*-fitting).
+
+4. Work through the [VASP tutorials](Tutorials/VASP/) — bulk InAs at PBE → PBE+SOC → HSE06, building toward DFT+U fitting.
+
+> `setup_utils.sh` only installs the FHI-aims tooling. The inorganic track installs its tools from the [Utilities page](Utilities/) instead.


### PR DESCRIPTION
## Summary
Refinements to the VASP tutorials, Perlmutter onboarding tooling, and the Utilities page. `incar.py` is now the single source of truth — every displayed INCAR was regenerated by running the script.

## Changes
**The three INCAR inconsistencies**
- `KPAR`: 4 on one CPU node (T2–T4), 16 for the 4-node HSE run (T5) — matches the automation flags and the Perlmutter KPAR table.
- `ENCUT`: 350 → 400 in the Tutorial 2 reference block.
- Displayed INCARs now match `incar.py` output verbatim (alignment, comments, `TIME`).

**incar.py**
- Column-aligned comments (left-aligned `#`).
- HSE uses `ALGO = All` (not Fast); HSE-DOS still dedups to `ALGO = None`.
- `LREAL = .False.` for the small InAs cells.

**VASPKIT alternatives** — added to Tutorials 3–5, tested against the staged 1.6.0 CLI. Corrected the hybrid-band task to **252** (the old "213 = HSE" table entry was wrong).

**Utilities**
- Added OgreInterface and BayesianOpt4dftu (Marom-group QM packages).
- Added an AI coding-assistants section (Claude Code / Codex).
- VASPKIT install: the SourceForge binary targets an older glibc and won't run on Perlmutter — use the 1.6.0 build under `shared_folder`.
- Cross-linked tool mentions across the tutorials.

**Quick Onboard** — split into organic (FHI-aims) vs inorganic (VASP) tracks + training mission statement. **README** — brief project overview.

## Validation
- `jekyll build` is green; all new anchors and tables render.
- `incar.py` re-run for every flag combination; outputs match the docs.
- Only VASP/Perlmutter + shared Utilities/landing/README touched — no FHI-aims files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
